### PR TITLE
Fix placeholder parsing to preserve tokens

### DIFF
--- a/src/lib/pptx-parser.ts
+++ b/src/lib/pptx-parser.ts
@@ -102,7 +102,9 @@ export class PPTXParser {
       // 1) Text runs like <a:t>...{{title}}...</a:t>
       if (doc) {
         const allTextNodes = Array.from(doc.getElementsByTagName('*')).filter(el => el.localName === 't');
-        const textContent = allTextNodes.map(el => el.textContent || '').join(' ');
+        // Join without adding separator so placeholder tokens split across runs
+        // (e.g. "{{ti" + "tle}}") are preserved as "{{title}}".
+        const textContent = allTextNodes.map(el => el.textContent || '').join('');
         const textMatches = textContent.match(/\{\{([^}]+)\}\}/g) || [];
         console.log(`PPTXParser: [a:t] found ${textMatches.length} placeholders in slide ${index + 1}:`, textMatches);
         textMatches.forEach(m => pushUnique(index, m.replace(/[{}]/g, '')));


### PR DESCRIPTION
## Summary
- avoid inserting extra spaces between text runs when extracting placeholder keys
- document the reasoning so split placeholder tokens (e.g. `{{ti` + `tle}}`) remain intact for export replacement

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da90222b6c832ca6108f368f4b660a